### PR TITLE
Update the /set-pasta command

### DIFF
--- a/src/main/kotlin/com/github/mckernant1/lol/blitzcrank/commands/pasta/SetPastaCommand.kt
+++ b/src/main/kotlin/com/github/mckernant1/lol/blitzcrank/commands/pasta/SetPastaCommand.kt
@@ -10,7 +10,7 @@ class SetPastaCommand(event: CommandInfo) : DiscordCommand(event) {
     constructor(event: SlashCommandEvent) : this(CommandInfo(event))
     constructor(event: MessageReceivedEvent) : this(CommandInfo(event))
     override fun execute() {
-        userSettings.pasta = event.commandString.replace("!setPasta ", "")
+        userSettings.pasta = event.commandString.replace("/set-Pasta ", "")
         UserSettings.putSettings(userSettings)
         event.channel.sendMessage("Your Pasta has been set to ${userSettings.pasta}").complete()
     }


### PR DESCRIPTION
Looks like;
A. The setPasta command is actually set-pasta
B. The ! is actually a / when you download the bot.

I suggest this change so that the pasta does not contain /set-pasta in it.